### PR TITLE
make interfaces more transparent/usable

### DIFF
--- a/src/lingtreemaps/__init__.py
+++ b/src/lingtreemaps/__init__.py
@@ -15,7 +15,6 @@ import requests
 import seaborn as sns
 import shapely
 import shapely.geometry
-import yaml
 from Bio import Phylo
 import Bio.Phylo.Newick
 from matplotlib import patheffects

--- a/src/lingtreemaps/__init__.py
+++ b/src/lingtreemaps/__init__.py
@@ -12,6 +12,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import pandas as pd
 import requests
+import yaml
 import seaborn as sns
 import shapely
 import shapely.geometry

--- a/src/lingtreemaps/__init__.py
+++ b/src/lingtreemaps/__init__.py
@@ -12,10 +12,10 @@ import matplotlib
 import matplotlib.pyplot as plt
 import pandas as pd
 import requests
-import yaml
 import seaborn as sns
 import shapely
 import shapely.geometry
+import yaml
 from Bio import Phylo
 import Bio.Phylo.Newick
 from matplotlib import patheffects

--- a/src/lingtreemaps/cli.py
+++ b/src/lingtreemaps/cli.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import click
 import matplotlib.pyplot as plt
 import pandas as pd
-import yaml
 from Bio import Phylo
 import lingtreemaps
 

--- a/src/lingtreemaps/cli.py
+++ b/src/lingtreemaps/cli.py
@@ -13,19 +13,6 @@ import lingtreemaps
 log = logging.getLogger(__name__)
 
 
-def load_conf(conf_file="lingtreemaps.yaml"):
-    confpath = Path(conf_file)
-    if confpath.is_file():
-        with open(confpath, "r", encoding="utf-8") as f:
-            data = yaml.load(f, yaml.SafeLoader)
-            if data is not None:
-                return data
-            log.warning(f"Empty config file: {confpath.resolve()}")
-            return {}
-    log.error(f"Config file {confpath.resolve()} not found.")
-    return {}
-
-
 @click.group()
 def main():
     pass  # pragma: no cover
@@ -64,7 +51,7 @@ def plot(
     tree = Phylo.read(tree, "newick")
     kwargs = dict(filename=filename, file_format="pdf", debug=debug)
     if conf:
-        kwargs.update(**load_conf(conf))
+        kwargs.update(**lingtreemaps.load_conf(conf))
     else:
         log.info("Provide a conf file to style your map.")
     if feature:


### PR DESCRIPTION
This PR is mostly intended to clarify the API of `lingtreemaps`. I'm plying with using `lingtreemaps` from a `cldfviz` command. This would mean `lingtreemaps` can be used with CLDF data (and alternative integration with Glottolog). It looks like all I need is calling `lingtreemaps.load_conf` and `lingtreemaps.plot`.