### PR TITLE
shapely 1.7 compat

### DIFF
--- a/src/lingtreemaps/__init__.py
+++ b/src/lingtreemaps/__init__.py
@@ -20,12 +20,14 @@ import yaml
 from Bio import Phylo
 from matplotlib import patheffects
 from matplotlib.patches import Patch
-from shapely.errors import ShapelyDeprecationWarning
-
+try:
+    from shapely.errors import ShapelyDeprecationWarning
+    warnings.filterwarnings("ignore", category=ShapelyDeprecationWarning)
+except ImportError:
+    pass
 
 __all__ = ['plot', 'get_glottolog_csv', 'download_glottolog_tree', 'load_conf']
 
-warnings.filterwarnings("ignore", category=ShapelyDeprecationWarning)
 
 handler = colorlog.StreamHandler(None)
 handler.setFormatter(


### PR DESCRIPTION
Since `shapely>=1.8` breaks things on Ubuntu 20.04, compatibility with `shapely==1.7.1` would be good.